### PR TITLE
use fallback for emoji

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.1"
-source = "git+https://github.com/araxeus/dialoguer#0c17c421d8d745c88c39e1b7652e35c848fae6a3"
+source = "git+https://github.com/araxeus/dialoguer#d8633df7b72390c76166e1a8f8b90a339b9e4811"
 dependencies = [
  "console",
  "crossterm",

--- a/src/structs/entry.rs
+++ b/src/structs/entry.rs
@@ -17,9 +17,9 @@ impl fmt::Display for Entry {
             console::Emoji(
                 self.icon.to_str(),
                 if self.filetype == Filetype::Directory {
-                    ">"
+                    "\\"
                 } else {
-                    "-"
+                    " "
                 }
             ),
             self.name

--- a/src/structs/entry.rs
+++ b/src/structs/entry.rs
@@ -11,7 +11,19 @@ pub struct Entry {
 
 impl fmt::Display for Entry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}", self.icon, self.name)
+        write!(
+            f,
+            "{} {}",
+            console::Emoji(
+                self.icon.to_str(),
+                if self.filetype == Filetype::Directory {
+                    ">"
+                } else {
+                    "-"
+                }
+            ),
+            self.name
+        )
     }
 }
 

--- a/src/structs/icons.rs
+++ b/src/structs/icons.rs
@@ -4,6 +4,12 @@ use std::fmt;
 
 pub struct Icon(&'static str);
 
+impl Icon {
+    pub const fn to_str(&self) -> &'static str {
+        self.0
+    }
+}
+
 impl fmt::Display for Icon {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)


### PR DESCRIPTION
On terminal that don't support emoji's:

![image](https://user-images.githubusercontent.com/78568641/169122940-f098a64a-5e28-4233-86ae-e6e55778f698.png)

->

![image](https://user-images.githubusercontent.com/78568641/169590228-69953a64-0009-4d3a-928f-1701e4be4945.png)

related: https://github.com/Araxeus/dialoguer/pull/9