### PR TITLE
Unix Fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.1"
-source = "git+https://github.com/araxeus/dialoguer#23b9ca936ca11d0b03d16805f8ec84d9b6e78c50"
+source = "git+https://github.com/araxeus/dialoguer#d8633df7b72390c76166e1a8f8b90a339b9e4811"
 dependencies = [
  "console",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.1"
-source = "git+https://github.com/araxeus/dialoguer#0c17c421d8d745c88c39e1b7652e35c848fae6a3"
+source = "git+https://github.com/araxeus/dialoguer#23b9ca936ca11d0b03d16805f8ec84d9b6e78c50"
 dependencies = [
  "console",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.1"
-source = "git+https://github.com/araxeus/dialoguer#0c17c421d8d745c88c39e1b7652e35c848fae6a3"
+source = "git+https://github.com/araxeus/dialoguer#5982f7fd4c94c714c1ba7d61abdda6f8d039cbba"
 dependencies = [
  "console",
  "crossterm",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 🌟 Browse folders using <kbd>Enter</kbd>
 
-🌟 Open folder in terminal (cd to folder) using <kbd>Shift</kbd> + <kbd>Enter</kbd>
+🌟 Open folder in terminal (cd to folder) using [<kbd>Shift</kbd> + <kbd>Enter</kbd>] or [<kbd>Alt</kbd> + <kbd>Enter</kbd>]
 
 🌟 Open folder in file manager using <kbd>Ctrl</kbd> + <kbd>Enter</kbd>
 
@@ -33,12 +33,19 @@
 
 🌟 Type anything to filter current folder content using fuzzy search
 
+> on Linux/Mac <kbd>Shift</kbd> + <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd> might not work
+>
+> see https://github.com/crossterm-rs/crossterm/issues/669
+
 ## 🛠 Installation
 
 1. Download zip package from [releases page](https://github.com/Araxeus/ls-interactive/releases)
 2. extract its content into a folder in PATH ([guide](https://gist.github.com/nex3/c395b2f8fd4b02068be37c961301caa7))
 
-Installation from package managers is Coming Soon™
+#### Linux/Mac
+Copy the function in [lsi.sh](https://github.com/Araxeus/ls-interactive/blob/master/scripts/lsi.sh) into to `/home/user/.bashrc`
+
+(You need only the ls-interactive file in your PATH, since lsi is defined in your bash startup file)
 
 ## 💻 How to run it
 

--- a/scripts/lsi.sh
+++ b/scripts/lsi.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#add the following function to /home/user/.bashrc
 
-output=$("$(dirname "$0")/ls-interactive")
-[ -n "$output" ] && cd "$(output)"
+lsi() {
+  local output
+  if output=$(ls-interactive "$@") && [[ $output ]] ; then
+    cd "$output"
+  fi
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main_loop(initial_path: String) {
             entry.path.to_string()
         };
 
-        if modifier == KeyModifiers::SHIFT {
+        if modifier == KeyModifiers::SHIFT || modifier == KeyModifiers::ALT {
             print!("{}", pretty_path(&path));
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,10 @@ fn main_loop(initial_path: String) {
                 // quit if file was opened
                 Ok(_) => break,
                 // else display error and open as directory
-                Err(_) => err(format!("Failed to open file \"{}\"", pretty_path(&entry.path))),
+                Err(_) => err(format!(
+                    "Failed to open file \"{}\"",
+                    pretty_path(&entry.path)
+                )),
             }
         }
         // browse directory by continuing loop with new path

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod utils;
 use std::{env, fs, path::Path};
 
 use structs::{Entry, Filetype, Icons};
-use utils::{display_choices, err, resolve_lnk, KeyModifiers};
+use utils::{display_choices, err, pretty_path, resolve_lnk, KeyModifiers};
 
 fn main() {
     human_panic::setup_panic!();
@@ -35,7 +35,7 @@ fn main_loop(initial_path: String) {
                 // quit if file was opened
                 Ok(_) => break,
                 // else display error and open as directory
-                Err(_) => err(format!("Failed to open file \"{}\"", &entry.path[4..])),
+                Err(_) => err(format!("Failed to open file \"{}\"", pretty_path(&entry.path))),
             }
         }
         // browse directory by continuing loop with new path
@@ -46,7 +46,7 @@ fn main_loop(initial_path: String) {
         };
 
         if modifier == KeyModifiers::SHIFT {
-            print!("{}", &path[4..]);
+            print!("{}", pretty_path(&path));
             break;
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,7 +21,7 @@ pub fn resolve_lnk(path: &String) -> String {
     mem::drop(panic::take_hook());
 
     if link.is_err() {
-        err(format!("Failed to read shortcut \"{}\"", &path[4..]));
+        err(format!("Failed to read shortcut \"{}\"", pretty_path(path)));
         return path.to_string();
     }
 
@@ -40,7 +40,7 @@ pub fn resolve_lnk(path: &String) -> String {
 // returns the index of the selected choice
 pub fn display_choices(items: &[Entry], path: &str) -> (usize, KeyModifiers) {
     match FuzzySelect::with_theme(&ColorfulTheme::default())
-        .with_prompt(&path[4..])
+        .with_prompt(pretty_path(path))
         .report(false)
         .items(items)
         .default(0)
@@ -50,5 +50,13 @@ pub fn display_choices(items: &[Entry], path: &str) -> (usize, KeyModifiers) {
         Some(res) => res,
         // exit process if none
         None => process::exit(0),
+    }
+}
+
+pub fn pretty_path(path: &str) -> &str {
+    if cfg!(windows) {
+        &path[4..]
+    } else {
+        path
     }
 }


### PR DESCRIPTION
* Fix selection for unix (fix #8)
  There is still a bug present: <kbd>Enter</kbd> doesn't register <kbd>Shift</kbd>/<kbd>Ctrl</kbd> modifiers, only 
 <kbd>Alt</kbd>,
  so now folder can be opened via either <kbd>Shift</kbd> or <kbd>Alt</kbd>

  see also  https://github.com/Araxeus/dialoguer/pull/8
  

* Fix path being unnecessarily cut on Unix

* Unix installation now involves adding a function to `.bashrc`


