### PR TITLE
Revert "use fallback for emoji"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.1"
-source = "git+https://github.com/araxeus/dialoguer#d8633df7b72390c76166e1a8f8b90a339b9e4811"
+source = "git+https://github.com/araxeus/dialoguer#0c17c421d8d745c88c39e1b7652e35c848fae6a3"
 dependencies = [
  "console",
  "crossterm",

--- a/src/structs/entry.rs
+++ b/src/structs/entry.rs
@@ -11,19 +11,7 @@ pub struct Entry {
 
 impl fmt::Display for Entry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{} {}",
-            console::Emoji(
-                self.icon.to_str(),
-                if self.filetype == Filetype::Directory {
-                    "\\"
-                } else {
-                    " "
-                }
-            ),
-            self.name
-        )
+        write!(f, "{} {}", self.icon, self.name)
     }
 }
 

--- a/src/structs/icons.rs
+++ b/src/structs/icons.rs
@@ -4,12 +4,6 @@ use std::fmt;
 
 pub struct Icon(&'static str);
 
-impl Icon {
-    pub const fn to_str(&self) -> &'static str {
-        self.0
-    }
-}
-
 impl fmt::Display for Icon {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)


### PR DESCRIPTION
Reverts Araxeus/ls-interactive#9

`console::Emoji` is broken and use fallback even on terminal that support emoji's (for example gnome-terminal)