### PR TITLE
Added a command for fish shell

### DIFF
--- a/scripts/lsi.fish
+++ b/scripts/lsi.fish
@@ -1,0 +1,14 @@
+#!/usr/bin/env fish
+
+# Command for ls-interactive use.
+# Copy this file into ~/.config/fish/functions/
+# to have it accessible at all times.
+
+function lsi
+    set -l output (ls-interactive $argv)
+    if test $status -eq 0
+        and test -n "$output"
+        cd $output
+    end
+end
+

--- a/scripts/lsi.fish
+++ b/scripts/lsi.fish
@@ -5,7 +5,7 @@
 # to have it accessible at all times.
 
 function lsi
-    set -l output (ls-interactive $argv)
+    set -l output (ls-interactive "$argv")
     if test $status -eq 0
         and test -n "$output"
         cd $output


### PR DESCRIPTION
This script makes lsi work on my setup (Ubuntu 20.04 + fish), although to select a directory the key is Alt+Enter.