### PR TITLE
Internal Renderer + Additional shells support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,15 +73,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "console"
-version = "0.15.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
  "unicode-width",
- "windows-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -166,12 +168,6 @@ dependencies = [
  "toml",
  "uuid",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -459,6 +455,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -34,9 +34,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -61,9 +61,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -81,14 +81,14 @@ dependencies = [
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "crossterm"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "dialoguer"
 version = "0.10.1"
-source = "git+https://github.com/araxeus/dialoguer#5982f7fd4c94c714c1ba7d61abdda6f8d039cbba"
+source = "git+https://github.com/araxeus/dialoguer#0741ea45c82b8a07d1f67d03eb48287de5467b5a"
 dependencies = [
  "console",
  "crossterm",
@@ -137,20 +137,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "human-panic"
@@ -175,9 +175,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lnk"
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -230,23 +230,23 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -271,18 +271,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "open"
@@ -291,23 +291,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
 dependencies = [
  "pathdiff",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "os_type"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3df761f6470298359f84fcfb60d86db02acc22c251c37265c07a3d1057d2389"
+checksum = "e24d44c0eea30167516ed8f6daca4b5e3eebcde1bde1e4e6e08b809fb02c7ba5"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -315,15 +315,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -334,36 +334,36 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustc-demangle"
@@ -390,15 +390,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -437,19 +437,19 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -472,30 +472,30 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
+name = "unicode-ident"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "uuid"
@@ -505,12 +505,6 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"
@@ -551,30 +545,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -585,21 +566,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -609,21 +578,9 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -636,12 +593,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,17 +112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.10.1"
-source = "git+https://github.com/araxeus/dialoguer#0741ea45c82b8a07d1f67d03eb48287de5467b5a"
-dependencies = [
- "console",
- "crossterm",
- "fuzzy-matcher",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,10 +201,12 @@ name = "ls-interactive"
 version = "1.3.0"
 dependencies = [
  "console",
- "dialoguer",
+ "crossterm",
+ "fuzzy-matcher",
  "human-panic",
  "lnk",
  "open",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ls", "lsi", "cli", "interactive", "explorer", "list", "files", "fol
 categories = ["command-line-utilities"]
 
 [dependencies]
-console = "0.15.3"
+console = "=0.15.0" # ANY LATER VERSION BREAKS SCROLLING (0.15.1 - 0.15.3 tested)
 open = "3.2.0"
 human-panic = "1.0.3"
 lnk = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ console = "=0.15.0" # ANY LATER VERSION BREAKS SCROLLING (0.15.1 - 0.15.3 tested
 open = "3.2.0"
 human-panic = "1.0.3"
 lnk = "0.4.1"
-dialoguer = { version = "0.10.1", default-features = false, features = ["fuzzy-select"] }
-
-[patch.crates-io]
-dialoguer = { git = 'https://github.com/araxeus/dialoguer' }
+fuzzy-matcher = "0.3.7"
+crossterm = "0.24.0"
+unicode-segmentation = "1.9.0"

--- a/README.md
+++ b/README.md
@@ -17,23 +17,21 @@
 
 ## ⚡ Features
 
-🌟 Navigate between folders using arrow keys
+🌟 Navigate between folders/files using arrow keys
 
-🌟 Browse folders using <kbd>Enter</kbd>
+🌟 Browse folders / Open files with native apps using using <kbd>Enter</kbd>
 
-🌟 Open folder in terminal (cd to folder) using [<kbd>Shift</kbd> + <kbd>Enter</kbd>] or [<kbd>Alt</kbd> + <kbd>Enter</kbd>]
+🌟 Open folder in terminal (CD to folder) using <kbd>Shift</kbd>+<kbd>Enter</kbd> or <kbd>Alt</kbd>+<kbd>Enter</kbd>
 
-🌟 Open folder in file manager using <kbd>Ctrl</kbd> + <kbd>Enter</kbd>
-
-🌟 Open files with native apps using <kbd>Enter</kbd>
-
-🌟 Top button (📁 ..) opens the parent directory
-
-🌟 Press <kbd>Esc</kbd> to exit
+🌟 Open folder in file manager using <kbd>Ctrl</kbd>+<kbd>Enter</kbd>
 
 🌟 Type anything to filter current folder content using fuzzy search
 
-> on Linux/Mac <kbd>Shift</kbd> + <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd> might not work
+🌟 Top button (📁 ..) opens the parent directory (<kbd>LeftArrow</kbd> can also be used when fuzzy text field is empty)
+
+🌟 Press <kbd>Esc</kbd> to exit
+
+> on Linux/Mac <kbd>Shift</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>Enter</kbd> *might* not work
 >
 > see https://github.com/crossterm-rs/crossterm/issues/669
 
@@ -123,7 +121,7 @@ lsi
 or
 
 ```bash
-lsi some_directory
+lsi some_relative_path
 ```
 
 ## ⚙️ Build it yourself

--- a/README.md
+++ b/README.md
@@ -40,12 +40,79 @@
 ## 🛠 Installation
 
 1. Download zip package from [releases page](https://github.com/Araxeus/ls-interactive/releases)
-2. extract its content into a folder in PATH ([guide](https://gist.github.com/nex3/c395b2f8fd4b02068be37c961301caa7))
+   
+2. Extract its content into a folder in PATH ([guide](https://gist.github.com/nex3/c395b2f8fd4b02068be37c961301caa7))
+   
+3. Follow shell specific instructions:
+<details>
+  <summary><bold>Bash (Linux/Mac)</bold></summary>
 
-#### Linux/Mac
-Copy the function in [lsi.sh](https://github.com/Araxeus/ls-interactive/blob/master/scripts/lsi.sh) into to `/home/user/.bashrc`
+  * Copy the `lsi` function from [scripts/lsi.sh](https://github.com/Araxeus/ls-interactive/blob/master/scripts/lsi.sh) into to `/home/user/.bashrc`
 
-(You need only the ls-interactive file in your PATH, since lsi is defined in your bash startup file)
+    ```bash
+    gedit /home/user/.bashrc
+    ```
+ 
+</details>
+
+<details>
+  <summary><bold>Batch (Windows)</bold></summary>
+
+  * Copy [scripts/lsi.bat](https://github.com/Araxeus/ls-interactive/blob/master/scripts/lsi.sh) into a folder in your `%PATH%` environment variable
+
+    you can open you envionment variables settings using the following command:
+
+    ```batch
+    rundll32.exe sysdm.cpl,EditEnvironmentVariables
+    ```
+ 
+</details>
+
+<details>
+  <summary><bold>Fish Shell</bold></summary>
+
+  * Copy [scripts/lsi.fish](https://github.com/Araxeus/ls-interactive/blob/master/scripts/lsi.fish) into `~/.config/fish/functions/`
+   
+    (Windows WSL is currently unsupported)
+
+  
+ 
+</details>
+<details>
+  <summary><bold>Powershell</bold></summary>
+
+  * Copy the `lsi` function from [scripts/lsi.ps1](https://github.com/Araxeus/ls-interactive/blob/master/scripts/lsi.ps1) to your `Microsoft.PowerShell_profile.ps1`
+
+    you can open your profile using one of the following commands:
+
+    ```ps1
+    notepad $profile
+    ```
+    <br>
+   
+    ```ps1
+    gedit $profile
+    ```
+ 
+</details>
+
+<details>
+  <summary><bold>Nushell</bold></summary>
+
+  * Copy the `lsi` function from [scripts/lsi.nu](https://github.com/Araxeus/ls-interactive/blob/master/scripts/lsi.nu) to your `env.nu`
+
+    you can open your profile using one of the following commands:
+
+    ```bash
+    notepad $nu.env-path
+    ```
+    <br>
+   
+    ```bash
+    gedit $nu.env-path
+    ```
+ 
+</details>
 
 ## 💻 How to run it
 

--- a/scripts/lsi.bat
+++ b/scripts/lsi.bat
@@ -1,3 +1,5 @@
+::place both this script and ls-interactive.exe in your PATH
+
 @echo off
 for /f "tokens=*" %%i in ('%~dp0\ls-interactive.exe "%*"') do set output=%%i
 IF DEFINED output cd %output%

--- a/scripts/lsi.bat
+++ b/scripts/lsi.bat
@@ -1,3 +1,3 @@
 @echo off
-for /f "tokens=*" %%i in ('%~dp0\ls-interactive.exe %*') do set output=%%i
+for /f "tokens=*" %%i in ('%~dp0\ls-interactive.exe "%*"') do set output=%%i
 cd %output%

--- a/scripts/lsi.bat
+++ b/scripts/lsi.bat
@@ -1,3 +1,3 @@
 @echo off
 for /f "tokens=*" %%i in ('%~dp0\ls-interactive.exe "%*"') do set output=%%i
-cd %output%
+IF DEFINED output cd %output%

--- a/scripts/lsi.fish
+++ b/scripts/lsi.fish
@@ -1,0 +1,14 @@
+#!/usr/bin/env fish
+
+# Command for ls-interactive use.
+# Copy this file into ~/.config/fish/functions/
+# to have it accessible at all times.
+
+function lsi
+    set -l output (ls-interactive $argv)
+    if test $status -eq 0
+        and test -n "$output"
+        cd $output
+    end
+end
+

--- a/scripts/lsi.fish
+++ b/scripts/lsi.fish
@@ -5,7 +5,7 @@
 # to have it accessible at all times.
 
 function lsi
-    set -l output (ls-interactive $argv)
+    set -l output (ls-interactive "$argv")
     if test $status -eq 0
         and test -n "$output"
         cd $output

--- a/scripts/lsi.nu
+++ b/scripts/lsi.nu
@@ -1,5 +1,7 @@
 # add the following function to env.nu
-# you can open it via the following command in nushell:
+# you can edit your config using one of the following commands:
+
+# gedit $nu.env-path
 # notepad $nu.env-path
 
 def-env lsi [...path: string] {

--- a/scripts/lsi.nu
+++ b/scripts/lsi.nu
@@ -1,0 +1,11 @@
+# add the following function to env.nu
+# you can open it via the following command in nushell:
+# notepad $nu.env-path
+
+def-env lsi [...path: string] {
+    let output = (ls-interactive ($path | str collect ' '))
+    cd (
+        if ($output | empty?) { $env.PWD } 
+        else { $output }
+    )
+}

--- a/scripts/lsi.nu
+++ b/scripts/lsi.nu
@@ -7,7 +7,7 @@
 def-env lsi [...path: string] {
     let output = (ls-interactive ($path | str collect ' '))
     cd (
-        if ($output | empty?) { $env.PWD } 
+        if ($output | is-empty) { $env.PWD } 
         else { $output }
     )
 }

--- a/scripts/lsi.ps1
+++ b/scripts/lsi.ps1
@@ -5,10 +5,10 @@
 
 # which will open either:
 
-# New Powershell:
+# pwsh (New Powershell):
 # C:\Users\MyUser\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
 
-# Old Powershell
+# powershell (Old Powershell):
 # C:\Users\MyUser\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
 
 

--- a/scripts/lsi.ps1
+++ b/scripts/lsi.ps1
@@ -1,0 +1,20 @@
+# paste the following function inside your Microsoft.PowerShell_profile.ps1
+# you can open it using the following command:
+
+# notepad $profile
+
+# which will open either:
+
+# New Powershell:
+# C:\Users\MyUser\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
+
+# Old Powershell
+# C:\Users\MyUser\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+
+
+function lsi {
+    $output = (ls-interactive "$args")
+    if ($output) {
+        cd $output
+    }
+}

--- a/scripts/lsi.ps1
+++ b/scripts/lsi.ps1
@@ -1,20 +1,10 @@
-# paste the following function inside your Microsoft.PowerShell_profile.ps1
-# you can open it using the following command:
+# add the following function to your Microsoft.PowerShell_profile.ps1
+# you can open your profile using one of the following commands:
 
 # notepad $profile
-
-# which will open either:
-
-# pwsh (New Powershell):
-# C:\Users\MyUser\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
-
-# powershell (Old Powershell):
-# C:\Users\MyUser\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
-
+# gedit $profile
 
 function lsi {
     $output = (ls-interactive "$args")
-    if ($output) {
-        cd $output
-    }
+    if ($output) { Set-Location $output }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,19 @@
 mod structs;
 mod utils;
 
-use std::{env, fs, path::Path};
+use std::{fs, path::Path};
 
 use structs::{Entry, Filetype, Icons};
-use utils::{display_choices, err, pretty_path, resolve_lnk, KeyModifiers};
+use utils::{display_choices, err, get_first_arg, pretty_path, resolve_lnk, KeyModifiers};
 
 fn main() {
     human_panic::setup_panic!();
 
-    let args: Vec<String> = env::args().collect();
-
     // path = first arg or current dir
-    let path = if args.len() >= 2 { args[1].trim() } else { "." };
+    let path = match get_first_arg() {
+        Some(path) => path,
+        None => String::from("."),
+    };
 
     match fs::canonicalize(path) {
         Ok(path) => main_loop(path.to_string_lossy().to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,15 +10,12 @@ fn main() {
     human_panic::setup_panic!();
 
     // path = first arg or current dir
-    let path = match get_first_arg() {
-        Some(path) => path,
-        None => String::from("."),
-    };
+    let path = get_first_arg().map_or_else(|| String::from("."), |path| path);
 
-    match fs::canonicalize(path) {
-        Ok(path) => main_loop(path.to_string_lossy().to_string()),
-        Err(_) => err("Invalid path"),
-    }
+    fs::canonicalize(path).map_or_else(
+        |_| err("Invalid Path"),
+        |path| main_loop(path.to_string_lossy().to_string()),
+    );
 }
 
 fn main_loop(initial_path: String) {

--- a/src/structs/entry.rs
+++ b/src/structs/entry.rs
@@ -19,10 +19,11 @@ impl Entry {
     pub fn from_dir_entry(entry: &fs::DirEntry) -> Self {
         let path = entry.path();
 
-        let filetype = match entry.file_type() {
-            Ok(native_file_type) => Filetype::from_native(native_file_type, &path),
-            Err(_) => Filetype::Unknown,
-        };
+        let filetype = entry
+            .file_type()
+            .map_or(Filetype::Unknown, |native_file_type| {
+                Filetype::from_native(native_file_type, &path)
+            });
 
         Self {
             name: entry.file_name().to_string_lossy().to_string(),

--- a/src/structs/filetype.rs
+++ b/src/structs/filetype.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum Filetype {
     Text, // (default)
     Executable,

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -1,5 +1,13 @@
 mod entry;
 mod filetype;
 mod icons;
+mod prompt;
+mod prompt_renderer;
 
-pub use crate::structs::{entry::Entry, filetype::Filetype, icons::Icon, icons::Icons};
+pub use crate::structs::{
+    entry::Entry,
+    filetype::Filetype,
+    icons::{Icon, Icons},
+    prompt::Prompt,
+    prompt_renderer::ColorfulTheme,
+};

--- a/src/structs/prompt.rs
+++ b/src/structs/prompt.rs
@@ -1,0 +1,268 @@
+use super::prompt_renderer::{SimpleTheme, TermRenderer, Theme};
+use console::Term;
+use crossterm::{
+    event::{read, Event, KeyCode, KeyEvent, KeyModifiers},
+    terminal,
+};
+
+use fuzzy_matcher::FuzzyMatcher;
+use std::io;
+use unicode_segmentation::UnicodeSegmentation;
+
+/// Renders a selection menu that user can fuzzy match to reduce set.
+///
+/// User can use fuzzy search to limit selectable items.
+/// Interaction returns index of an item selected in the order they appear in `item` invocation or `items` slice.
+
+pub struct Prompt<'a> {
+    default: usize,
+    items: Vec<String>,
+    title: String,
+    report: bool,
+    clear: bool,
+    highlight_matches: bool,
+    theme: &'a dyn Theme,
+}
+
+impl Default for Prompt<'static> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Prompt<'static> {
+    /// Creates the prompt with a specific text.
+    pub fn new() -> Self {
+        Self::with_theme(&SimpleTheme)
+    }
+}
+
+impl Prompt<'_> {
+    /// Adds multiple items to the fuzzy selector.
+    pub fn items<T: ToString>(&mut self, items: &[T]) -> &mut Self {
+        for item in items {
+            self.items.push(item.to_string());
+        }
+        self
+    }
+
+    /// Prefaces the menu with a prompt.
+    ///
+    /// When a prompt is set the system also prints out a confirmation after
+    /// the fuzzy selection.
+    pub fn title<S: Into<String>>(&mut self, title: S) -> &mut Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Enables user interaction and returns the result.
+    ///
+    /// The user can select the items using 'Enter' and the index of selected item will be returned.
+    /// The dialog is rendered on stderr.
+    /// Result contains `Some(index)` if user hit 'Enter' or `None` if user cancelled with 'Esc' or 'q'.
+    #[inline]
+    pub fn run(&self) -> io::Result<Option<(usize, KeyModifiers)>> {
+        self._run(&Term::stderr(), true)
+    }
+
+    /// Like `interact` but allows a specific terminal to be set.
+    /// Ignore `clippy::too-many-lines`
+    #[allow(clippy::too_many_lines)] // TODO: refactor
+    fn _run(&self, term: &Term, allow_quit: bool) -> io::Result<Option<(usize, KeyModifiers)>> {
+        // This cursor iterates over the graphemes vec rather than the search term
+        let mut cursor_pos = 0;
+        let mut search_term: Vec<String> = Vec::new();
+
+        let mut render = TermRenderer::new(term, self.theme);
+        let mut sel = self.default;
+
+        let mut size_vec = Vec::new();
+        for items in self.items.iter().as_slice() {
+            let size = &items.len();
+            size_vec.push(*size);
+        }
+
+        // Fuzzy matcher
+        let matcher = fuzzy_matcher::skim::SkimMatcherV2::default();
+
+        // Subtract -2 because we need space to render the prompt.
+        let visible_term_rows = (term.size().0 as usize).max(3) - 2;
+        // Variable used to determine if we need to scroll through the list.
+        let mut starting_row = 0;
+
+        term.hide_cursor()?;
+
+        loop {
+            let concatted_search_term = search_term.concat();
+            search_term = concatted_search_term
+                .graphemes(true)
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<String>>();
+
+            render.clear()?;
+            render.fuzzy_select_prompt(self.title.as_str(), &search_term, cursor_pos)?;
+
+            // Maps all items to a tuple of item and its match score.
+            let mut filtered_list = self
+                .items
+                .iter()
+                .map(|item| (item, matcher.fuzzy_match(item, &search_term.concat())))
+                .filter_map(|(item, score)| score.map(|s| (item, s)))
+                .collect::<Vec<_>>();
+
+            // Renders all matching items, from best match to worst.
+            filtered_list.sort_unstable_by(|(_, s1), (_, s2)| s2.cmp(s1));
+
+            for (idx, (item, _)) in filtered_list
+                .iter()
+                .enumerate()
+                .skip(starting_row)
+                .take(visible_term_rows)
+            {
+                render.fuzzy_select_prompt_item(
+                    item,
+                    idx == sel,
+                    self.highlight_matches,
+                    &matcher,
+                    &search_term.concat(),
+                )?;
+                term.flush()?;
+            }
+
+            terminal::enable_raw_mode()?;
+
+            if let Event::Key(KeyEvent { code, modifiers }) = read().unwrap() {
+                match code {
+                    KeyCode::Esc if allow_quit => {
+                        if self.clear {
+                            render.clear()?;
+                            term.flush()?;
+                        }
+                        terminal::disable_raw_mode()?;
+                        term.show_cursor()?;
+                        return Ok(None);
+                    }
+                    KeyCode::Up | KeyCode::BackTab if !filtered_list.is_empty() => {
+                        if sel == 0 {
+                            starting_row =
+                                filtered_list.len().max(visible_term_rows) - visible_term_rows;
+                        } else if sel == starting_row {
+                            starting_row -= 1;
+                        }
+
+                        sel = (sel + filtered_list.len() - 1) % filtered_list.len();
+                        term.flush()?;
+                    }
+                    KeyCode::Down | KeyCode::Tab if !filtered_list.is_empty() => {
+                        sel = (sel + filtered_list.len() + 1) % filtered_list.len();
+                        if sel == visible_term_rows + starting_row {
+                            starting_row += 1;
+                        } else if sel == 0 {
+                            starting_row = 0;
+                        }
+                        term.flush()?;
+                    }
+                    KeyCode::Left => {
+                        if cursor_pos > 0 {
+                            cursor_pos -= 1;
+                            term.flush()?;
+                        } else if search_term.is_empty() {
+                            if self.clear {
+                                render.clear()?;
+                            }
+
+                            terminal::disable_raw_mode()?;
+
+                            term.show_cursor()?;
+
+                            return Ok(Some((0, KeyModifiers::NONE)));
+                        }
+                    }
+                    KeyCode::Right => {
+                        if cursor_pos < search_term.len() {
+                            cursor_pos += 1;
+                            term.flush()?;
+                        } else if search_term.is_empty()
+                            && filtered_list[sel].0.find('📁').is_some()
+                        {
+                            if self.clear {
+                                render.clear()?;
+                            }
+                            let sel_string = filtered_list[sel].0;
+                            let sel_string_pos_in_items = self
+                                .items
+                                .iter()
+                                .position(|item| item.eq(sel_string))
+                                .unwrap();
+
+                            terminal::disable_raw_mode()?;
+
+                            term.show_cursor()?;
+
+                            return Ok(Some((sel_string_pos_in_items, KeyModifiers::NONE)));
+                        }
+                    }
+                    KeyCode::Enter if !filtered_list.is_empty() => {
+                        if self.clear {
+                            render.clear()?;
+                        }
+
+                        if self.report {
+                            render.input_prompt_selection(
+                                self.title.as_str(),
+                                filtered_list[sel].0,
+                            )?;
+                        }
+
+                        let sel_string = filtered_list[sel].0;
+                        let sel_string_pos_in_items = self
+                            .items
+                            .iter()
+                            .position(|item| item.eq(sel_string))
+                            .unwrap();
+
+                        terminal::disable_raw_mode()?;
+
+                        term.show_cursor()?;
+
+                        return Ok(Some((sel_string_pos_in_items, modifiers)));
+                    }
+                    KeyCode::Backspace if cursor_pos > 0 => {
+                        cursor_pos -= 1;
+                        search_term.remove(cursor_pos);
+                        term.flush()?;
+                    }
+                    KeyCode::Char(chr) if !chr.is_ascii_control() => {
+                        search_term.insert(cursor_pos, chr.to_string());
+                        cursor_pos += 1;
+                        term.flush()?;
+                        sel = 0;
+                        starting_row = 0;
+                    }
+
+                    KeyCode::Null => render.error("Unrecognized Key").unwrap(),
+
+                    _ => {}
+                }
+            }
+
+            terminal::disable_raw_mode()?;
+            render.clear_preserve_prompt(&size_vec)?;
+        }
+    }
+}
+
+impl<'a> Prompt<'a> {
+    /// Same as `new` but with a specific theme.
+    pub fn with_theme(theme: &'a dyn Theme) -> Self {
+        Self {
+            default: 0,
+            items: vec![],
+            title: String::new(),
+            report: false,
+            clear: true,
+            highlight_matches: true,
+            theme,
+        }
+    }
+}

--- a/src/structs/prompt_renderer.rs
+++ b/src/structs/prompt_renderer.rs
@@ -1,0 +1,409 @@
+//! Customizes the rendering of the elements.
+use std::{fmt, io};
+
+use console::{style, Style, StyledObject, Term};
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+
+/// Implements a theme for dialoguer.
+pub trait Theme {
+    /// Formats a prompt.
+    #[inline]
+    fn format_prompt(&self, f: &mut dyn fmt::Write, prompt: &str) -> fmt::Result {
+        write!(f, "{prompt}:")
+    }
+
+    /// Formats out an error.
+    #[inline]
+    fn format_error(&self, f: &mut dyn fmt::Write, err: &str) -> fmt::Result {
+        write!(f, "error: {err}")
+    }
+
+    /// Formats an input prompt after selection.
+    #[inline]
+    fn format_input_prompt_selection(
+        &self,
+        f: &mut dyn fmt::Write,
+        prompt: &str,
+        sel: &str,
+    ) -> fmt::Result {
+        write!(f, "{prompt}: {sel}")
+    }
+
+    /// Formats a fuzzy select prompt item.
+    fn format_fuzzy_select_prompt_item(
+        &self,
+        f: &mut dyn fmt::Write,
+        text: &str,
+        active: bool,
+        highlight_matches: bool,
+        matcher: &SkimMatcherV2,
+        search_term: &str,
+    ) -> fmt::Result {
+        write!(f, "{} ", if active { ">" } else { " " })?;
+
+        if highlight_matches {
+            if let Some((_score, indices)) = matcher.fuzzy_indices(text, search_term) {
+                for (idx, c) in text.chars().into_iter().enumerate() {
+                    if indices.contains(&idx) {
+                        write!(f, "{}", style(c).for_stderr().bold())?;
+                    } else {
+                        write!(f, "{c}")?;
+                    }
+                }
+
+                return Ok(());
+            }
+        }
+
+        write!(f, "{text}")
+    }
+
+    /// Formats a fuzzy select prompt.
+    fn format_fuzzy_select_prompt(
+        &self,
+        f: &mut dyn fmt::Write,
+        prompt: &str,
+        search_term: &[String],
+        cursor_pos: usize,
+    ) -> fmt::Result {
+        if !prompt.is_empty() {
+            write!(f, "{prompt} ",)?;
+        }
+
+        if cursor_pos < search_term.len() {
+            let split = search_term.split_at(cursor_pos);
+            let head = split.0.concat();
+            let cursor = "|".to_string();
+            let tail = split.1.concat();
+
+            write!(f, "{head}{cursor}{tail}")
+        } else {
+            let cursor = "|".to_string();
+            write!(f, "{}{cursor}", search_term.concat())
+        }
+    }
+}
+
+/// The default theme.
+pub struct SimpleTheme;
+
+impl Theme for SimpleTheme {}
+
+/// A colorful theme
+pub struct ColorfulTheme {
+    /// The style for default values
+    pub defaults_style: Style,
+    /// The style for prompt
+    pub prompt_style: Style,
+    /// Prompt prefix value and style
+    pub prompt_prefix: StyledObject<String>,
+    /// Prompt suffix value and style
+    pub prompt_suffix: StyledObject<String>,
+    /// Prompt on success prefix value and style
+    pub success_prefix: StyledObject<String>,
+    /// Prompt on success suffix value and style
+    pub success_suffix: StyledObject<String>,
+    /// Error prefix value and style
+    pub error_prefix: StyledObject<String>,
+    /// The style for error message
+    pub error_style: Style,
+    /// The style for hints
+    pub hint_style: Style,
+    /// The style for values on prompt success
+    pub values_style: Style,
+    /// The style for active items
+    pub active_item_style: Style,
+    /// The style for inactive items
+    pub inactive_item_style: Style,
+    /// Active item in select prefix value and style
+    pub active_item_prefix: StyledObject<String>,
+    /// Inctive item in select prefix value and style
+    pub inactive_item_prefix: StyledObject<String>,
+    /// Checked item in multi select prefix value and style
+    pub checked_item_prefix: StyledObject<String>,
+    /// Unchecked item in multi select prefix value and style
+    pub unchecked_item_prefix: StyledObject<String>,
+    /// Picked item in sort prefix value and style
+    pub picked_item_prefix: StyledObject<String>,
+    /// Unpicked item in sort prefix value and style
+    pub unpicked_item_prefix: StyledObject<String>,
+    /// Formats the cursor for a fuzzy select prompt
+    pub fuzzy_cursor_style: Style,
+    // Formats the highlighting of matched characters
+    pub fuzzy_match_highlight_style: Style,
+    /// Show the selections from certain prompts inline
+    pub inline_selections: bool,
+}
+
+impl Default for ColorfulTheme {
+    fn default() -> Self {
+        Self {
+            defaults_style: Style::new().for_stderr().cyan(),
+            prompt_style: Style::new().for_stderr().bold(),
+            prompt_prefix: style("?".to_string()).for_stderr().yellow(),
+            prompt_suffix: style("›".to_string()).for_stderr().black().bright(),
+            success_prefix: style("✔".to_string()).for_stderr().green(),
+            success_suffix: style("·".to_string()).for_stderr().black().bright(),
+            error_prefix: style("✘".to_string()).for_stderr().red(),
+            error_style: Style::new().for_stderr().red(),
+            hint_style: Style::new().for_stderr().black().bright(),
+            values_style: Style::new().for_stderr().green(),
+            active_item_style: Style::new().for_stderr().cyan(),
+            inactive_item_style: Style::new().for_stderr(),
+            active_item_prefix: style("❯".to_string()).for_stderr().green(),
+            inactive_item_prefix: style(" ".to_string()).for_stderr(),
+            checked_item_prefix: style("✔".to_string()).for_stderr().green(),
+            unchecked_item_prefix: style("✔".to_string()).for_stderr().black(),
+            picked_item_prefix: style("❯".to_string()).for_stderr().green(),
+            unpicked_item_prefix: style(" ".to_string()).for_stderr(),
+            fuzzy_cursor_style: Style::new().for_stderr().black().on_white(),
+            fuzzy_match_highlight_style: Style::new().for_stderr().bold(),
+            inline_selections: true,
+        }
+    }
+}
+
+impl Theme for ColorfulTheme {
+    /// Formats a prompt.
+    fn format_prompt(&self, f: &mut dyn fmt::Write, prompt: &str) -> fmt::Result {
+        if !prompt.is_empty() {
+            write!(
+                f,
+                "{} {} ",
+                &self.prompt_prefix,
+                self.prompt_style.apply_to(prompt)
+            )?;
+        }
+
+        write!(f, "{}", &self.prompt_suffix)
+    }
+
+    /// Formats an error
+    fn format_error(&self, f: &mut dyn fmt::Write, err: &str) -> fmt::Result {
+        write!(
+            f,
+            "{} {}",
+            &self.error_prefix,
+            self.error_style.apply_to(err)
+        )
+    }
+
+    /// Formats an input prompt after selection.
+    fn format_input_prompt_selection(
+        &self,
+        f: &mut dyn fmt::Write,
+        prompt: &str,
+        sel: &str,
+    ) -> fmt::Result {
+        if !prompt.is_empty() {
+            write!(
+                f,
+                "{} {} ",
+                &self.success_prefix,
+                self.prompt_style.apply_to(prompt)
+            )?;
+        }
+
+        write!(
+            f,
+            "{} {}",
+            &self.success_suffix,
+            self.values_style.apply_to(sel)
+        )
+    }
+
+    /// Formats a fuzzy select prompt item.
+    fn format_fuzzy_select_prompt_item(
+        &self,
+        f: &mut dyn fmt::Write,
+        text: &str,
+        active: bool,
+        highlight_matches: bool,
+        matcher: &SkimMatcherV2,
+        search_term: &str,
+    ) -> fmt::Result {
+        //check if char is right to left aligned (arabic/hebrew unicode range)
+        fn is_rtl(c: char) -> bool {
+            ('\u{0591}'..='\u{07FF}').contains(&c) // c >= '\u{0591}' && c <= '\u{07FF}'
+        }
+
+        write!(
+            f,
+            "{} ",
+            if active {
+                &self.active_item_prefix
+            } else {
+                &self.inactive_item_prefix
+            }
+        )?;
+
+        if highlight_matches {
+            if let Some((_score, indices)) = matcher.fuzzy_indices(text, search_term) {
+                for (idx, c) in text.chars().into_iter().enumerate() {
+                    if indices.contains(&idx) && !is_rtl(c) {
+                        if active {
+                            write!(
+                                f,
+                                "{}",
+                                self.active_item_style
+                                    .apply_to(self.fuzzy_match_highlight_style.apply_to(c))
+                            )?;
+                        } else {
+                            write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c))?;
+                        }
+                    } else if active {
+                        write!(f, "{}", self.active_item_style.apply_to(c))?;
+                    } else {
+                        write!(f, "{c}")?;
+                    }
+                }
+
+                return Ok(());
+            }
+        }
+
+        write!(f, "{text}")
+    }
+
+    /// Formats a fuzzy-selectprompt after selection.
+    fn format_fuzzy_select_prompt(
+        &self,
+        f: &mut dyn fmt::Write,
+        prompt: &str,
+        search_term: &[String], // This should be Vec<str>
+        cursor_pos: usize,
+    ) -> fmt::Result {
+        if !prompt.is_empty() {
+            write!(
+                f,
+                "{} {} ",
+                &self.prompt_prefix,
+                self.prompt_style.apply_to(prompt)
+            )?;
+        }
+
+        if cursor_pos < search_term.len() {
+            let split = search_term.split_at(cursor_pos);
+            let head = split.0.concat();
+            let cursor = self.fuzzy_cursor_style.apply_to(split.1.get(0).unwrap());
+            let tail = split.1[1..].concat();
+
+            write!(f, "{} {head}{cursor}{tail}", &self.prompt_suffix)
+        } else {
+            let cursor = self.fuzzy_cursor_style.apply_to(" ");
+            write!(
+                f,
+                "{} {}{}",
+                &self.prompt_suffix,
+                search_term.concat(),
+                cursor
+            )
+        }
+    }
+}
+
+/// Helper struct to conveniently render a theme ot a term.
+pub struct TermRenderer<'a> {
+    term: &'a Term,
+    theme: &'a dyn Theme,
+    height: usize,
+    prompt_height: usize,
+    prompts_reset_height: bool,
+}
+
+impl<'a> TermRenderer<'a> {
+    pub fn new(term: &'a Term, theme: &'a dyn Theme) -> TermRenderer<'a> {
+        TermRenderer {
+            term,
+            theme,
+            height: 0,
+            prompt_height: 0,
+            prompts_reset_height: true,
+        }
+    }
+
+    pub fn error(&mut self, err: &str) -> io::Result<()> {
+        self.write_formatted_line(|this, buf| this.theme.format_error(buf, err))
+    }
+
+    fn write_formatted_line<F: FnOnce(&mut TermRenderer, &mut dyn fmt::Write) -> fmt::Result>(
+        &mut self,
+        f: F,
+    ) -> io::Result<()> {
+        let mut buf = String::new();
+        f(self, &mut buf).map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        self.height += buf.chars().filter(|&x| x == '\n').count() + 1;
+        self.term.write_line(&buf)
+    }
+
+    fn write_formatted_prompt<F: FnOnce(&mut TermRenderer, &mut dyn fmt::Write) -> fmt::Result>(
+        &mut self,
+        f: F,
+    ) -> io::Result<()> {
+        self.write_formatted_line(f)?;
+        if self.prompts_reset_height {
+            self.prompt_height = self.height;
+            self.height = 0;
+        }
+        Ok(())
+    }
+
+    pub fn input_prompt_selection(&mut self, prompt: &str, sel: &str) -> io::Result<()> {
+        self.write_formatted_prompt(|this, buf| {
+            this.theme.format_input_prompt_selection(buf, prompt, sel)
+        })
+    }
+
+    pub fn fuzzy_select_prompt(
+        &mut self,
+        prompt: &str,
+        search_term: &[String],
+        cursor_pos: usize,
+    ) -> io::Result<()> {
+        self.write_formatted_prompt(|this, buf| {
+            this.theme
+                .format_fuzzy_select_prompt(buf, prompt, search_term, cursor_pos)
+        })
+    }
+
+    pub fn fuzzy_select_prompt_item(
+        &mut self,
+        text: &str,
+        active: bool,
+        highlight: bool,
+        matcher: &SkimMatcherV2,
+        search_term: &str,
+    ) -> io::Result<()> {
+        self.write_formatted_line(|this, buf| {
+            this.theme.format_fuzzy_select_prompt_item(
+                buf,
+                text,
+                active,
+                highlight,
+                matcher,
+                search_term,
+            )
+        })
+    }
+
+    pub fn clear(&mut self) -> io::Result<()> {
+        self.term
+            .clear_last_lines(self.height + self.prompt_height)?;
+        self.height = 0;
+        Ok(())
+    }
+
+    pub fn clear_preserve_prompt(&mut self, size_vec: &[usize]) -> io::Result<()> {
+        let mut new_height = self.height;
+        //Check each item size, increment on finding an overflow
+        for size in size_vec {
+            if *size > self.term.size().1 as usize {
+                new_height += 1;
+            }
+        }
+
+        self.term.clear_last_lines(new_height)?;
+        self.height = 0;
+        Ok(())
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,8 @@
-use crate::structs::Entry;
+use crate::structs::{ColorfulTheme, Entry, Prompt};
 
-use console::{style, Term};
+use console::style;
 
-pub use dialoguer::KeyModifiers;
-use dialoguer::{theme::ColorfulTheme, FuzzySelect};
+pub use crossterm::event::KeyModifiers;
 
 use lnk::ShellLink;
 
@@ -40,12 +39,10 @@ pub fn resolve_lnk(path: &String) -> String {
 // dialoguer select from a list of choices
 // returns the index of the selected choice
 pub fn display_choices(items: &[Entry], path: &str) -> (usize, KeyModifiers) {
-    FuzzySelect::with_theme(&ColorfulTheme::default())
-        .with_prompt(pretty_path(path))
-        .report(false)
+    Prompt::with_theme(&ColorfulTheme::default())
+        .title(pretty_path(path))
         .items(items)
-        .default(0)
-        .interact_on_opt(&Term::stderr())
+        .run()
         .unwrap()
         .map_or_else(|| process::exit(0), |res| res)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,10 +7,10 @@ use dialoguer::{theme::ColorfulTheme, FuzzySelect};
 
 use lnk::ShellLink;
 
-use std::{fmt::Display, fs, mem, panic, process};
+use std::{env, fmt::Display, fs, mem, panic, process};
 
 pub fn err<S: Display>(msg: S) {
-    eprintln!("{} {}", style("Error").red(), msg);
+    eprintln!("{} {}", style("Error:").red().for_stderr(), msg);
 }
 
 pub fn resolve_lnk(path: &String) -> String {
@@ -51,6 +51,17 @@ pub fn display_choices(items: &[Entry], path: &str) -> (usize, KeyModifiers) {
         // exit process if none
         None => process::exit(0),
     }
+}
+
+pub fn get_first_arg() -> Option<String> {
+    env::args().nth(1).and_then(|arg| {
+        let arg = arg.trim();
+        if arg.is_empty() {
+            None
+        } else {
+            Some(arg.to_owned())
+        }
+    })
 }
 
 pub fn pretty_path(path: &str) -> &str {


### PR DESCRIPTION
* Remove `dialoguer` dependency and by switching to internal prompt renderer

* Allow using Left/Right arrow to navigate folders when the fuzzy text field is empty

* Add shell support (expands on #13)
  - [x] pwsh/powershell
  - [x] fish
  - [x] Nu (Nushell)
  - [ ] Zsh (Z-Shell) - should be able to just put the function from `lsi.sh` inside `.zshrc`?
  - [ ] Ksh (Korn Shell) ?
  - [ ] Tcsh (Tenex C Shell) ?

* Refactor/lint + small bug fixes

* Update README
