### PR TITLE
add `no-exec`/`-x` flag

### DIFF
--- a/scripts/cli-editor/README.md
+++ b/scripts/cli-editor/README.md
@@ -1,0 +1,6 @@
+# Command Line Editor Scripts
+
+The scripts in this folder enable you to choose a text editor to use for editing files in the command line.
+
+All the scripts use `micro` as the default editor.
+If you want to use a different editor, replace `micro` with the name of your editor in the scripts. (for example, `vim` or `nano` or `code`)

--- a/scripts/cli-editor/lsi.bat
+++ b/scripts/cli-editor/lsi.bat
@@ -1,0 +1,15 @@
+:: Place both this script and ls-interactive.exe in one of the folders in your %PATH%
+:: You can open your environment variables by running "rundll32.exe sysdm.cpl,EditEnvironmentVariables"
+
+@echo off
+for /f "tokens=*" %%i in ('%~dp0\ls-interactive.exe -x "%*"') do set output=%%i
+IF DEFINED output CALL :exec %output%
+GOTO :EOF
+
+:exec
+    SET file_attribute=%~a1
+    if "%file_attribute:~0,1%"=="d" (
+        cd %1
+    ) else (
+         micro %1
+    )

--- a/scripts/cli-editor/lsi.fish
+++ b/scripts/cli-editor/lsi.fish
@@ -1,0 +1,16 @@
+#!/usr/bin/env fish
+
+# Command for ls-interactive use.
+# Copy this file into ~/.config/fish/functions/ OR copy this function into your config.fish
+
+function lsi
+    set -l output
+    if output=(ls-interactive $argv -x); and [ -n "$output" ]
+        if test -f "$output"
+            micro "$output"
+        else
+            cd "$output"
+        end
+    end
+end
+

--- a/scripts/cli-editor/lsi.nu
+++ b/scripts/cli-editor/lsi.nu
@@ -1,0 +1,10 @@
+# add the following function to env.nu
+# you can open env.nu in nushell with `config env`
+
+def-env lsi [...path: string] {
+    let output = (ls-interactive -x ($path | str join ' '))
+    if ($output | is-empty) { return }
+    if (($output | path type) == 'file') { 
+        micro $output 
+    } else { cd $output }
+}

--- a/scripts/cli-editor/lsi.ps1
+++ b/scripts/cli-editor/lsi.ps1
@@ -1,0 +1,12 @@
+# add the following function to your Microsoft.PowerShell_profile.ps1
+# you can open your profile using one of the following commands:
+
+# notepad $profile
+# gedit $profile
+
+function lsi {
+    $output = (ls-interactive -x "$args")
+    if (!$output) { return }
+    if (Test-Path -Path $output -PathType leaf) { micro $output }
+    else { Set-Location $output }
+}

--- a/scripts/cli-editor/lsi.sh
+++ b/scripts/cli-editor/lsi.sh
@@ -1,0 +1,12 @@
+# Add the following function to /home/user/.bashrc or /home/user/.zshrc
+
+lsi() {
+    local output
+    if output=$(ls-interactive "$@" -x) && [[ $output ]]; then
+        if [ -f "$output" ]; then
+            micro "$output"
+        else
+            cd "$output"
+        fi
+    fi
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,15 +18,46 @@ fn main() {
     );
 
     // path = first arg or current dir
-    let path = get_first_arg().map_or_else(|| String::from("."), |path| path);
+    let mut path = get_first_arg().map_or_else(|| String::from("."), |path| path);
+
+    if path == "--help" || path == "-h" {
+        println!(
+            "Usage: {} [path] [flags]
+
+Flags:
+    -v, --version   Print version   
+    -h, --help      Print help
+    -x, --no-exec   Don't execute files
+",
+            env!("CARGO_PKG_NAME")
+        );
+        return;
+    }
+
+    if path == "--version" || path == "-v" {
+        println!("{}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
+    let no_exec_flags = ["--no-exec", "--noexec", "-x"];
+
+    let mut no_exec = false;
+    if let Some(index) = no_exec_flags.iter().position(|&flag| path.contains(flag)) {
+        no_exec = true;
+        let flag = no_exec_flags[index];
+        path = path.replace(flag, "").trim().to_owned();
+        if path.is_empty() {
+            path = String::from(".");
+        }
+    }
 
     fs::canonicalize(path).map_or_else(
         |_| err("Invalid Path"),
-        |path| main_loop(path.to_string_lossy().to_string()),
+        |path| main_loop(path.to_string_lossy().to_string(), no_exec),
     );
 }
 
-fn main_loop(initial_path: String) {
+fn main_loop(initial_path: String, no_exec: bool) {
     let mut selected_entry = Entry {
         path: initial_path,
         ..Default::default()
@@ -50,6 +81,10 @@ fn main_loop(initial_path: String) {
 
         // exec file
         if entry.filetype.should_exec() || modifier == KeyModifiers::CONTROL {
+            if no_exec {
+                print!("{}", pretty_path(&entry.path));
+                break;
+            }
             match open::that(&entry.path) {
                 // quit if file was opened
                 Ok(_) => break,


### PR DESCRIPTION
Allows using `lsi` to choose a file and open in your favorite CLI editor using the <kbd>Enter</kbd> key

see https://github.com/Araxeus/ls-interactive/tree/add-no-exec/-x-flags/scripts/cli-editor

# Bash | sh |  zsh

```bash
lsi() {
    local output
    if output=$(ls-interactive "$@" -x) && [[ $output ]]; then
        if [ -f "$output" ]; then
            vim "$output" # I use micro instead of vim
        else
            cd "$output"
        fi
    fi
}
```

# Batch (Windows CMD)

```batch
@echo off
for /f "tokens=*" %%i in ('%~dp0\ls-interactive.exe -x "%*"') do set output=%%i
IF DEFINED output CALL :exec %output%
GOTO :EOF

:exec
    SET file_attribute=%~a1
    if "%file_attribute:~0,1%"=="d" (
        cd %1
    ) else (
         micro %1
    )
```

# PowerShell

```pwsh
function lsi {
    $output = (ls-interactive -x "$args")
    if (!$output) { return }
    if (Test-Path -Path $output -PathType leaf) { micro $output }
    else { Set-Location $output }
}
```

# Fish

```fish
function lsi
    set -l output
    if output=(ls-interactive $argv -x); and [ -n "$output" ]
        if test -f "$output"
            micro "$output"
        else
            cd "$output"
        end
    end
end
```

# Nushell 

```nu
def-env lsi [...path: string] {
    let output = (ls-interactive -x ($path | str join ' '))
    if ($output | is-empty) { return }
    if (($output | path type) == 'file') { 
        micro $output 
    } else { cd $output }
}
```