### PR TITLE
fix nushell v0.87.0

### DIFF
--- a/scripts/lsi.nu
+++ b/scripts/lsi.nu
@@ -1,10 +1,10 @@
 # add the following function to env.nu
 # you can open env.nu in nushell with `config env`
 
-def-env lsi [...path: string] {
+def --env lsi [...path: string] {
     let output = (ls-interactive ($path | str join ' '))
-    cd (
-        if ($output | is-empty) { $env.PWD } 
-        else { $output }
-    )
+    if ($output | is-empty) { return }
+    if (($output | path type) == 'file') { 
+        start $output # replace with your preferred editor
+    } else { cd $output }
 }


### PR DESCRIPTION
use `def --env` instead of deprecated `def-env`  and support launching files

https://www.nushell.sh/blog/2023-11-14-nushell_0_87_0.html#deprecated-commands-toc